### PR TITLE
bump: docker base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.2.1
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.6
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val installPHPCPD: String =
   s"""|export COMPOSER_HOME=/home/docker/.composer &&
       |mkdir -p /home/docker/.composer &&
       |chown -R docker:docker /home/docker &&
-      |apk --update --no-cache add openjdk8-jre bash curl git php8 php8-xml php8-cli php8-pdo php8-curl php8-json php8-phar php8-ctype php8-openssl php8-dom &&
+      |apk --update --no-cache add openjdk8-jre bash curl git php8 php8-xml php8-cli php8-pdo php8-curl php8-json php8-phar php8-ctype php8-openssl php8-dom php8-iconv &&
       |curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer &&
       |su - docker -c 'composer global require "sebastian/phpcpd=$phpCPDVersion"' &&
       |apk del curl &&
@@ -40,7 +40,7 @@ val installPHPCPD: String =
 Docker / packageName := packageName.value
 Docker / version := version.value
 Docker / maintainer := "Codacy <team@codacy.com>"
-dockerBaseImage := "php:8.0-alpine3.14"
+dockerBaseImage := "php:8.1.13-alpine3.16"
 dockerUpdateLatest := true
 Docker / defaultLinuxInstallLocation := defaultDockerInstallationPath
 Docker / daemonUser := "docker"


### PR DESCRIPTION
Bump to latest docker image to remove vulnerabilities. `php8-iconv` had to be installed on this version of alpine to ensure a successful build.